### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,6 @@ Test::More=0.98
 [Prereqs]
 parent=0
 strict=0
-vars=0
 warnings=0
 Data::Dumper=0
 

--- a/lib/Log/ger/Heavy.pm
+++ b/lib/Log/ger/Heavy.pm
@@ -14,20 +14,20 @@ package
     Log::ger;
 
 #IFUNBUILT
-use vars qw(
-               $re_addr
-               %Levels
-               %Level_Aliases
-               $Current_Level
-               $_outputter_is_null
-               $_dumper
-               %Global_Hooks
-               %Package_Targets
-               %Per_Package_Hooks
-               %Hash_Targets
-               %Per_Hash_Hooks
-               %Object_Targets
-               %Per_Object_Hooks
+our (
+               $re_addr,
+               %Levels,
+               %Level_Aliases,
+               $Current_Level,
+               $_outputter_is_null,
+               $_dumper,
+               %Global_Hooks,
+               %Package_Targets,
+               %Per_Package_Hooks,
+               %Hash_Targets,
+               %Per_Hash_Hooks,
+               %Object_Targets,
+               %Per_Object_Hooks,
        );
 #END IFUNBUILT
 

--- a/t/plugin-multilevellog.t
+++ b/t/plugin-multilevellog.t
@@ -6,7 +6,7 @@ use Test::More 0.98;
 
 use Log::ger::Util;
 
-use vars '$str';
+our $str;
 use Log::ger::Output 'String', string => \$str;
 
 package My::P1;


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.

This dist already uses "our" elsewhere.